### PR TITLE
set -o pipefail to fail when have other error

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 set -x
+set -o pipefail
 curl -u "$browserstack_username:$browserstack_access_key" -X POST https://api-cloud.browserstack.com/app-automate/upload -F "file=@$upload_path" -F 'data={"custom_id": "'$custom_id'"}' | jq -j '.app_url' | envman add --key BROWSERSTACK_APP_URL


### PR DESCRIPTION
I am facing some problems on my workflow because concatenated commands returns errors but without pipefail I am receiving the incorrect status green (success) on my workflow.

Follow my evidence on comment below.