### PR TITLE
Add fallback to default id when no custom id is given

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,4 +2,8 @@
 set -e
 set -x
 set -o pipefail
+if [ -z "$custom_id" ]
+then
+      custom_id='default'
+fi
 curl -u "$browserstack_username:$browserstack_access_key" -X POST https://api-cloud.browserstack.com/app-automate/upload -F "file=@$upload_path" -F 'data={"custom_id": "'$custom_id'"}' | jq -j '.app_url' | envman add --key BROWSERSTACK_APP_URL


### PR DESCRIPTION
Custom id is not a must in order to upload to browser stack an apk, it is not required on browser stack flow , but when sending it as null the step fails. Im suggesting adding a fallback to a default custom id in order for the upload to work for those who don't fill this attribute.